### PR TITLE
Move job start to 7am to avoid potential clashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build and deploy tile server
 on:
   schedule:
-  - cron: 0 5 * * *
+  - cron: 0 7 * * *
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Dataset collection may not finish until 6am so a 5am start will miss some changes.