### PR TITLE
Revised bucket input parameters

### DIFF
--- a/task/build.sh
+++ b/task/build.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+s3_object_arn_regex="^arn:aws:s3:::([0-9A-Za-z-]*/)(.*)$"
+
+if ! [[ "$S3_OBJECT_ARN" =~ $s3_object_arn_regex ]]; then
+    echo "Received invalid S3 Object S3 ARN: $S3_OBJECT_ARN, skipping"
+    exit 1
+fi
+
+S3_BUCKET=${BASH_REMATCH[1]%/*}
+S3_KEY=${BASH_REMATCH[2]}
 DATABASE=${S3_KEY##*/}
 DATABASE_NAME=${DATABASE%.*}
 

--- a/task/docker-compose.yml
+++ b/task/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     build: .
     user: "${UID}:${GID}"
     environment:
-      S3_BUCKET: production-collection-data
-      S3_KEY: entity-builder/dataset/entity.sqlite3
+      S3_OBJECT_ARN: arn:aws:s3:::production-collection-data/entity-builder/dataset/entity.sqlite3
       EVENT_ID: test-event
       AWS_REGION: eu-west-2
       AWS_DEFAULT_REGION: eu-west-2


### PR DESCRIPTION
Revised input parameters into AWS S3 Object ARN instead of separate bucket and key; a necessary change since referencing via ARNs is the only reliable way the builder can be triggered via EventBridge on CloudTrail events.